### PR TITLE
Update js-snackbar.js

### DIFF
--- a/src/js-snackbar.js
+++ b/src/js-snackbar.js
@@ -65,7 +65,7 @@
         }
 
         function createNewContainer(target) {
-            container = document.createElement("div");
+            var container = document.createElement("div");
             container.classList.add("js-snackbar-container");
 
             if(_Options.fixed) {


### PR DESCRIPTION
I'm getting the error "Uncaught TypeError: Assignment to constant variable." in Edge 91.0.864.64 caused by an un-declared variable. This fixes it.