### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # js-snackbar
 
-## What is a Snackbar?
+## What is a SnackBar?
 
 According to [Material Design](https://material.io/design/components/snackbars.html) a Snackbar or Toast provides "brief messages about app processes at the bottom of the screen." 
 
 Generally, they should not have an icon associated with it and should be only one line on most devices.
 
-While this version of a Snackbar follows the Material Design semantics closely, it strays in several major ways.
+While this version of a SnackBar follows the Material Design semantics closely, it strays in several major ways.
 
-1. You can send multiple snackbars to a user at a time, as opposed to a single Snackbar at a time. 
-2. The Snackbar appears in the bottom right corner, as opposed to the bottom left or bottom center.
+1. You can send multiple snackbars to a user at a time, as opposed to a single snackbar at a time. 
+2. The SnackBar appears in the bottom right corner, as opposed to the bottom left or bottom center.
 
 ## Basic Usage
 
-Simply call `Snackbar()` to create the a notification message with default options, or pass an `options` object that includes some of the properties below in [Options](#options).
+Simply call `SnackBar()` to create the a notification message with default options, or pass an `options` object that includes some of the properties below in [Options](#options).
 
 ## Options
 
-To customize a Snackbar, pass the function a JS object with any of the following properties. All properties are optional.
+To customize a SnackBar, pass the function a JS object with any of the following properties. All properties are optional.
 
 | Property    | typeof               | Default Value   | Notes |
 | ----------- | -------------------- | --------------- | ----- |
@@ -45,4 +45,4 @@ Actions should be an array of objects matching the format
 }
 ```
 
-At minimum, an action must have a text field, which will simply create a dismiss button with custom text. Alternatively, you can specify a `function` property which defines a custom function to be run once the action is clicked. This can be anything and is passed no parameters. If function is defined but you still want the action click to dismiss the snackbar, then you can specify `dismiss = true` to indicate that, once your method has run to completion, then the action will be automatically dismissed.
+At minimum, an action must have a text field, which will simply create a dismiss button with custom text. Alternatively, you can specify a `function` property which defines a custom function to be run once the action is clicked. This can be anything and is passed no parameters. If function is defined but you still want the action click to dismiss the SnackBar, then you can specify `dismiss = true` to indicate that, once your method has run to completion, then the action will be automatically dismissed.


### PR DESCRIPTION
`Snackbar` should be `SnackBar` with a capital 'b' (particularly in the "how to use" section).
Resolves #76 